### PR TITLE
Add Polars engine for high-performance validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Thumbs.db
 
 # Docs
 site/
+.claude/settings.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+polars = [
+    "polars>=0.20.0",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",

--- a/src/dqflow/engines/__init__.py
+++ b/src/dqflow/engines/__init__.py
@@ -4,3 +4,10 @@ from dqflow.engines.base import Engine
 from dqflow.engines.pandas import PandasEngine
 
 __all__ = ["Engine", "PandasEngine"]
+
+try:
+    from dqflow.engines.polars import PolarsEngine
+
+    __all__ = [*__all__, "PolarsEngine"]
+except ImportError:
+    pass

--- a/src/dqflow/engines/polars.py
+++ b/src/dqflow/engines/polars.py
@@ -1,0 +1,279 @@
+"""Polars validation engine."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+try:
+    import polars as pl
+except ImportError as exc:
+    raise ImportError(
+        "polars is required for PolarsEngine. Install it with: pip install dqflow[polars]"
+    ) from exc
+
+from dqflow.column import Column
+from dqflow.contract import Contract
+from dqflow.engines.base import Engine
+from dqflow.result import CheckResult, ValidationResult
+
+
+class PolarsEngine(Engine):
+    """Validation engine for Polars DataFrames with native parallelism and lazy evaluation."""
+
+    def validate(
+        self,
+        df: pl.DataFrame | pl.LazyFrame,
+        contract: Contract,
+    ) -> ValidationResult:
+        if isinstance(df, pl.LazyFrame):
+            df = df.collect()
+
+        result = ValidationResult(contract_name=contract.name)
+        cache = self._build_stats_cache(df)
+
+        for col_name in contract.columns:
+            if col_name not in df.columns:
+                result.checks.append(
+                    CheckResult(
+                        name=f"column_exists:{col_name}",
+                        passed=False,
+                        message=f"Column '{col_name}' not found in DataFrame",
+                    )
+                )
+            else:
+                result.checks.append(
+                    CheckResult(name=f"column_exists:{col_name}", passed=True, message="")
+                )
+
+        for col_name, col_def in contract.columns.items():
+            if col_name not in df.columns:
+                continue
+            result.checks.extend(self._validate_column(df[col_name], col_name, col_def))
+
+        for rule in contract.rules:
+            result.checks.append(self._evaluate_rule(df, rule, cache))
+
+        return result
+
+    def _validate_column(
+        self,
+        series: pl.Series,
+        col_name: str,
+        col_def: Column,
+    ) -> list[CheckResult]:
+        checks: list[CheckResult] = []
+
+        if col_def.not_null:
+            null_count = series.null_count()
+            checks.append(
+                CheckResult(
+                    name=f"not_null:{col_name}",
+                    passed=null_count == 0,
+                    message=f"Found {null_count} null values" if null_count > 0 else "",
+                    details={"null_count": null_count},
+                )
+            )
+
+        if col_def.min is not None:
+            min_val = series.min()
+            passed = min_val is None or min_val >= col_def.min
+            checks.append(
+                CheckResult(
+                    name=f"min:{col_name}",
+                    passed=bool(passed),
+                    message=(
+                        f"Minimum value {min_val} is below {col_def.min}" if not passed else ""
+                    ),
+                    details={"actual_min": float(min_val) if min_val is not None else None},
+                )
+            )
+
+        if col_def.max is not None:
+            max_val = series.max()
+            passed = max_val is None or max_val <= col_def.max
+            checks.append(
+                CheckResult(
+                    name=f"max:{col_name}",
+                    passed=bool(passed),
+                    message=(
+                        f"Maximum value {max_val} exceeds {col_def.max}" if not passed else ""
+                    ),
+                    details={"actual_max": float(max_val) if max_val is not None else None},
+                )
+            )
+
+        if col_def.allowed is not None:
+            allowed_set = set(col_def.allowed)
+            unique_vals = set(series.drop_nulls().unique().to_list())
+            invalid = unique_vals - allowed_set
+            checks.append(
+                CheckResult(
+                    name=f"allowed:{col_name}",
+                    passed=len(invalid) == 0,
+                    message=f"Found invalid values: {invalid}" if invalid else "",
+                    details={"invalid_values": list(invalid)},
+                )
+            )
+
+        if col_def.freshness_minutes is not None:
+            checks.append(self._check_freshness(series, col_name, col_def.freshness_minutes))
+
+        if col_def.unique:
+            duplicate_count = int(series.is_duplicated().sum())
+            checks.append(
+                CheckResult(
+                    name=f"unique:{col_name}",
+                    passed=duplicate_count == 0,
+                    message=(
+                        f"Found {duplicate_count} duplicate values" if duplicate_count > 0 else ""
+                    ),
+                    details={"duplicate_count": duplicate_count},
+                )
+            )
+
+        if col_def.pattern is not None:
+            non_null = series.drop_nulls().cast(pl.String)
+            # Anchor at start to match pandas str.match (re.match) semantics
+            anchored = (
+                col_def.pattern if col_def.pattern.startswith("^") else f"^(?:{col_def.pattern})"
+            )
+            invalid_count = int((~non_null.str.contains(anchored)).sum())
+            checks.append(
+                CheckResult(
+                    name=f"pattern:{col_name}",
+                    passed=invalid_count == 0,
+                    message=(
+                        f"{invalid_count} values do not match pattern '{col_def.pattern}'"
+                        if invalid_count > 0
+                        else ""
+                    ),
+                    details={"invalid_count": invalid_count, "pattern": col_def.pattern},
+                )
+            )
+
+        if col_def.custom is not None:
+            try:
+                results = series.map_elements(col_def.custom, return_dtype=pl.Boolean)
+                passed_count = int(results.sum())
+                total_count = len(series)
+                checks.append(
+                    CheckResult(
+                        name=f"custom:{col_name}",
+                        passed=passed_count == total_count,
+                        message=(
+                            f"{total_count - passed_count} values failed custom check"
+                            if passed_count != total_count
+                            else ""
+                        ),
+                        details={"passed": passed_count, "total": total_count},
+                    )
+                )
+            except Exception as exc:
+                checks.append(
+                    CheckResult(
+                        name=f"custom:{col_name}",
+                        passed=False,
+                        message=f"Custom check raised exception: {exc}",
+                    )
+                )
+
+        return checks
+
+    def _check_freshness(
+        self,
+        series: pl.Series,
+        col_name: str,
+        freshness_minutes: int,
+    ) -> CheckResult:
+        try:
+            if "Date" not in str(series.dtype) and "Datetime" not in str(series.dtype):
+                series = series.cast(pl.String).str.to_datetime()
+
+            max_ts = series.max()
+
+            if max_ts is None:
+                return CheckResult(
+                    name=f"freshness:{col_name}",
+                    passed=False,
+                    message="No valid timestamps found",
+                )
+
+            now = datetime.now(timezone.utc)
+
+            if isinstance(max_ts, datetime) and max_ts.tzinfo is None:
+                max_ts = max_ts.replace(tzinfo=timezone.utc)
+
+            age = now - max_ts
+            threshold = timedelta(minutes=freshness_minutes)
+            passed = age <= threshold
+
+            return CheckResult(
+                name=f"freshness:{col_name}",
+                passed=passed,
+                message=f"Data is {age} old, threshold is {threshold}" if not passed else "",
+                details={
+                    "max_timestamp": max_ts.isoformat(),
+                    "age_minutes": age.total_seconds() / 60,
+                },
+            )
+
+        except Exception as exc:
+            return CheckResult(
+                name=f"freshness:{col_name}",
+                passed=False,
+                message=f"Failed to check freshness: {exc}",
+            )
+
+    def _build_stats_cache(
+        self,
+        df: pl.DataFrame,
+    ) -> dict[str, dict[str, float | int]]:
+        row_count = len(df)
+        return {
+            col: {
+                "null_rate": df[col].null_count() / row_count if row_count > 0 else 0.0,
+                "unique_count": df[col].n_unique(),
+                "row_count": row_count,
+            }
+            for col in df.columns
+        }
+
+    def _evaluate_rule(
+        self,
+        df: pl.DataFrame,
+        rule: str,
+        cache: dict[str, dict[str, float | int]],
+    ) -> CheckResult:
+        try:
+            result = self._parse_and_evaluate(df, rule, cache)
+            return CheckResult(
+                name=f"rule:{rule}",
+                passed=bool(result),
+                message="" if result else f"Rule '{rule}' failed",
+            )
+        except Exception as exc:
+            return CheckResult(
+                name=f"rule:{rule}",
+                passed=False,
+                message=f"Failed to evaluate rule: {exc}",
+            )
+
+    def _parse_and_evaluate(
+        self,
+        df: pl.DataFrame,
+        rule: str,
+        cache: dict[str, dict[str, float | int]],
+    ) -> Any:
+        context = {
+            "row_count": len(df),
+            "null_rate": lambda col: cache.get(col, {}).get("null_rate", 0),
+            "unique_count": lambda col: cache.get(col, {}).get("unique_count", 0),
+            "duplicate_rate": lambda col: (
+                (cache.get(col, {}).get("row_count", 0) - cache.get(col, {}).get("unique_count", 0))
+                / cache.get(col, {}).get("row_count", 1)
+                if cache.get(col)
+                else 0
+            ),
+        }
+        return eval(rule, {"__builtins__": {}}, context)

--- a/tests/test_polars_engine.py
+++ b/tests/test_polars_engine.py
@@ -1,0 +1,245 @@
+"""Tests for PolarsEngine."""
+
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+import pytest
+
+pl = pytest.importorskip("polars")
+
+from dqflow import Column, Contract  # noqa: E402
+from dqflow.engines.pandas import PandasEngine  # noqa: E402
+from dqflow.engines.polars import PolarsEngine  # noqa: E402
+
+
+@pytest.fixture
+def engine() -> PolarsEngine:
+    return PolarsEngine()
+
+
+@pytest.fixture
+def sample_pl_df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "order_id": ["A001", "A002", "A003"],
+            "amount": [100.0, 250.5, 75.0],
+            "currency": ["USD", "EUR", "USD"],
+            "created_at": [
+                datetime.now(timezone.utc) - timedelta(minutes=30),
+                datetime.now(timezone.utc) - timedelta(minutes=20),
+                datetime.now(timezone.utc) - timedelta(minutes=10),
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def sample_contract() -> Contract:
+    return Contract(
+        name="orders",
+        columns={
+            "order_id": Column(str, not_null=True),
+            "amount": Column(float, min=0),
+            "currency": Column(str, allowed=["USD", "EUR"]),
+        },
+        rules=["row_count > 0"],
+    )
+
+
+@pytest.fixture
+def violations_pl_df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "order_id": ["A001", None, "A003"],
+            "amount": [100.0, -50.0, 75.0],
+            "currency": ["USD", "GBP", "USD"],
+        }
+    )
+
+
+class TestPolarsEngineBasic:
+    def test_validate_passing(
+        self, engine: PolarsEngine, sample_pl_df: pl.DataFrame, sample_contract: Contract
+    ) -> None:
+        result = engine.validate(sample_pl_df, sample_contract)
+        assert result.ok is True
+        assert result.contract_name == "orders"
+
+    def test_validate_missing_column(self, engine: PolarsEngine, sample_contract: Contract) -> None:
+        df = pl.DataFrame({"order_id": ["A001"]})
+        result = engine.validate(df, sample_contract)
+        assert result.ok is False
+        assert any("amount" in c.name and not c.passed for c in result.checks)
+
+    def test_validate_null_violation(
+        self,
+        engine: PolarsEngine,
+        sample_contract: Contract,
+        violations_pl_df: pl.DataFrame,
+    ) -> None:
+        result = engine.validate(violations_pl_df, sample_contract)
+        assert result.ok is False
+        assert "not_null:order_id" in [c.name for c in result.failed_checks]
+
+    def test_validate_min_violation(
+        self,
+        engine: PolarsEngine,
+        sample_contract: Contract,
+        violations_pl_df: pl.DataFrame,
+    ) -> None:
+        result = engine.validate(violations_pl_df, sample_contract)
+        assert "min:amount" in [c.name for c in result.failed_checks]
+
+    def test_validate_allowed_violation(
+        self,
+        engine: PolarsEngine,
+        sample_contract: Contract,
+        violations_pl_df: pl.DataFrame,
+    ) -> None:
+        result = engine.validate(violations_pl_df, sample_contract)
+        assert "allowed:currency" in [c.name for c in result.failed_checks]
+
+    def test_validate_rule(self, engine: PolarsEngine, sample_pl_df: pl.DataFrame) -> None:
+        contract = Contract(name="test", rules=["row_count > 0", "row_count > 100"])
+        result = engine.validate(sample_pl_df, contract)
+        check_map = {c.name: c.passed for c in result.checks}
+        assert check_map["rule:row_count > 0"] is True
+        assert check_map["rule:row_count > 100"] is False
+
+
+class TestPolarsEngineConstraints:
+    def test_max_constraint_passing(self, engine: PolarsEngine) -> None:
+        df = pl.DataFrame({"score": [10.0, 20.0, 30.0]})
+        contract = Contract(name="test", columns={"score": Column(float, max=50.0)})
+        result = engine.validate(df, contract)
+        assert result.ok is True
+
+    def test_max_constraint_failing(self, engine: PolarsEngine) -> None:
+        df = pl.DataFrame({"score": [10.0, 20.0, 100.0]})
+        contract = Contract(name="test", columns={"score": Column(float, max=50.0)})
+        result = engine.validate(df, contract)
+        assert "max:score" in [c.name for c in result.failed_checks]
+
+    def test_unique_constraint_passing(self, engine: PolarsEngine) -> None:
+        df = pl.DataFrame({"id": [1, 2, 3]})
+        contract = Contract(name="test", columns={"id": Column(int, unique=True)})
+        result = engine.validate(df, contract)
+        assert result.ok is True
+
+    def test_unique_constraint_failing(self, engine: PolarsEngine) -> None:
+        df = pl.DataFrame({"id": [1, 2, 2]})
+        contract = Contract(name="test", columns={"id": Column(int, unique=True)})
+        result = engine.validate(df, contract)
+        assert "unique:id" in [c.name for c in result.failed_checks]
+
+    def test_pattern_constraint_passing(self, engine: PolarsEngine) -> None:
+        df = pl.DataFrame({"code": ["A001", "A002", "A003"]})
+        contract = Contract(name="test", columns={"code": Column(str, pattern=r"A\d{3}")})
+        result = engine.validate(df, contract)
+        assert result.ok is True
+
+    def test_pattern_constraint_failing(self, engine: PolarsEngine) -> None:
+        df = pl.DataFrame({"code": ["A001", "B999", "X123"]})
+        contract = Contract(name="test", columns={"code": Column(str, pattern=r"A\d{3}")})
+        result = engine.validate(df, contract)
+        assert "pattern:code" in [c.name for c in result.failed_checks]
+        detail = next(c for c in result.checks if c.name == "pattern:code")
+        assert detail.details["invalid_count"] == 2
+
+    def test_custom_constraint_passing(self, engine: PolarsEngine) -> None:
+        df = pl.DataFrame({"amount": [10.0, 20.0, 30.0]})
+        contract = Contract(name="test", columns={"amount": Column(float, custom=lambda x: x > 0)})
+        result = engine.validate(df, contract)
+        assert result.ok is True
+
+    def test_custom_constraint_failing(self, engine: PolarsEngine) -> None:
+        df = pl.DataFrame({"amount": [10.0, -5.0, 30.0]})
+        contract = Contract(name="test", columns={"amount": Column(float, custom=lambda x: x > 0)})
+        result = engine.validate(df, contract)
+        assert "custom:amount" in [c.name for c in result.failed_checks]
+
+    def test_freshness_passing(self, engine: PolarsEngine) -> None:
+        df = pl.DataFrame(
+            {
+                "ts": [
+                    datetime.now(timezone.utc) - timedelta(minutes=5),
+                    datetime.now(timezone.utc) - timedelta(minutes=2),
+                ]
+            }
+        )
+        contract = Contract(name="test", columns={"ts": Column(datetime, freshness_minutes=60)})
+        result = engine.validate(df, contract)
+        assert result.ok is True
+
+    def test_freshness_failing(self, engine: PolarsEngine) -> None:
+        df = pl.DataFrame(
+            {
+                "ts": [
+                    datetime.now(timezone.utc) - timedelta(hours=3),
+                    datetime.now(timezone.utc) - timedelta(hours=2),
+                ]
+            }
+        )
+        contract = Contract(name="test", columns={"ts": Column(datetime, freshness_minutes=60)})
+        result = engine.validate(df, contract)
+        assert "freshness:ts" in [c.name for c in result.failed_checks]
+
+
+class TestPolarsEngineLazyFrame:
+    def test_accepts_lazyframe(
+        self, engine: PolarsEngine, sample_pl_df: pl.DataFrame, sample_contract: Contract
+    ) -> None:
+        lazy_df = sample_pl_df.lazy()
+        result = engine.validate(lazy_df, sample_contract)
+        assert result.ok is True
+        assert result.contract_name == "orders"
+
+    def test_lazyframe_violations(
+        self, engine: PolarsEngine, violations_pl_df: pl.DataFrame, sample_contract: Contract
+    ) -> None:
+        result = engine.validate(violations_pl_df.lazy(), sample_contract)
+        assert result.ok is False
+        failed_names = [c.name for c in result.failed_checks]
+        assert "not_null:order_id" in failed_names
+        assert "min:amount" in failed_names
+        assert "allowed:currency" in failed_names
+
+
+class TestCrossEngineConsistency:
+    """Ensure PolarsEngine produces the same check outcomes as PandasEngine."""
+
+    def test_passing_contract_consistency(self, sample_contract: Contract) -> None:
+        pd_df = pd.DataFrame(
+            {
+                "order_id": ["A001", "A002", "A003"],
+                "amount": [100.0, 250.5, 75.0],
+                "currency": ["USD", "EUR", "USD"],
+            }
+        )
+        pl_df = pl.from_pandas(pd_df)
+
+        pandas_result = PandasEngine().validate(pd_df, sample_contract)
+        polars_result = PolarsEngine().validate(pl_df, sample_contract)
+
+        assert pandas_result.ok == polars_result.ok
+
+        pandas_map = {c.name: c.passed for c in pandas_result.checks}
+        polars_map = {c.name: c.passed for c in polars_result.checks}
+        assert pandas_map == polars_map
+
+    def test_violations_consistency(self, sample_contract: Contract) -> None:
+        pd_df = pd.DataFrame(
+            {
+                "order_id": ["A001", None, "A003"],
+                "amount": [100.0, -50.0, 75.0],
+                "currency": ["USD", "GBP", "USD"],
+            }
+        )
+        pl_df = pl.from_pandas(pd_df)
+
+        pandas_result = PandasEngine().validate(pd_df, sample_contract)
+        polars_result = PolarsEngine().validate(pl_df, sample_contract)
+
+        pandas_failed = {c.name for c in pandas_result.failed_checks}
+        polars_failed = {c.name for c in polars_result.failed_checks}
+        assert pandas_failed == polars_failed


### PR DESCRIPTION
## Summary

- Implements `PolarsEngine` extending `BaseEngine`, supporting both `pl.DataFrame` and `pl.LazyFrame` inputs
- Covers all column checks: `not_null`, `min`, `max`, `allowed`, `unique`, `pattern`, `freshness`, `custom`
- Rule evaluation uses the same `eval` context as `PandasEngine` (row_count, null_rate, unique_count, duplicate_rate)
- `PolarsEngine` is conditionally exported from `dqflow.engines` — gracefully skipped when polars is not installed
- Added `polars>=0.20.0` as an optional dependency (`pip install dqflow[polars]`)

## Test plan

- [x] 20 new tests in `tests/test_polars_engine.py` — all pass
- [x] Cross-engine consistency tests verify `PolarsEngine` produces identical pass/fail outcomes to `PandasEngine`
- [x] `LazyFrame` input is collected and validated correctly
- [x] Full suite: 46/46 tests pass, `ruff check` clean

Closes #4
