### PR TITLE
Add cross-column validation rules (no eval)

### DIFF
--- a/src/dqflow/__init__.py
+++ b/src/dqflow/__init__.py
@@ -1,8 +1,8 @@
 """dqflow - Lightweight, contract-first data quality engine."""
 
-from dqflow.column import Column
+from dqflow.column import Column, CrossColumnRule
 from dqflow.contract import Contract
 from dqflow.result import ValidationResult
 
 __version__ = "0.1.3"
-__all__ = ["Contract", "Column", "ValidationResult"]
+__all__ = ["Contract", "Column", "CrossColumnRule", "ValidationResult"]

--- a/src/dqflow/column.py
+++ b/src/dqflow/column.py
@@ -6,6 +6,40 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
+SUPPORTED_OPS: frozenset[str] = frozenset({">=", "<=", ">", "<", "==", "!="})
+
+
+@dataclass
+class CrossColumnRule:
+    """Row-level validation rule that compares two columns or a column against a literal."""
+
+    name: str
+    error_message: str = ""
+    check: Callable[[Any], Any] | None = None
+    left: str | None = None
+    op: str | None = None
+    right: str | int | float | None = None
+
+    def __post_init__(self) -> None:
+        has_callable = self.check is not None
+        has_structured = self.left is not None and self.op is not None and self.right is not None
+
+        if has_callable and has_structured:
+            raise ValueError(
+                f"CrossColumnRule '{self.name}': provide either 'check' or "
+                f"'left'/'op'/'right', not both."
+            )
+        if not has_callable and not has_structured:
+            raise ValueError(
+                f"CrossColumnRule '{self.name}': provide either 'check' or "
+                f"all of 'left', 'op', 'right'."
+            )
+        if has_structured and self.op not in SUPPORTED_OPS:
+            raise ValueError(
+                f"CrossColumnRule '{self.name}': unsupported op '{self.op}'. "
+                f"Must be one of: {sorted(SUPPORTED_OPS)}"
+            )
+
 
 @dataclass
 class Column:

--- a/src/dqflow/contract.py
+++ b/src/dqflow/contract.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
-from dqflow.column import Column
+from dqflow.column import Column, CrossColumnRule
 from dqflow.result import ValidationResult
 
 if TYPE_CHECKING:
@@ -46,6 +46,7 @@ class Contract:
     name: str
     columns: dict[str, Column] = field(default_factory=dict)
     rules: list[str] = field(default_factory=list)
+    cross_column_rules: list[CrossColumnRule] = field(default_factory=list)
     description: str = ""
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -74,10 +75,22 @@ class Contract:
             name: _ensure_column(col_def) for name, col_def in data.get("columns", {}).items()
         }
 
+        cross_column_rules = [
+            CrossColumnRule(
+                name=r["name"],
+                error_message=r.get("error_message", ""),
+                left=r.get("left"),
+                op=r.get("op"),
+                right=r.get("right"),
+            )
+            for r in data.get("cross_column_rules", [])
+        ]
+
         return cls(
             name=data.get("name", path.stem),
             columns=columns,
             rules=data.get("rules", []),
+            cross_column_rules=cross_column_rules,
             description=data.get("description", ""),
             metadata=data.get("metadata", {}),
         )
@@ -111,13 +124,29 @@ class Contract:
 
             columns_data[col_name] = col_dict
 
-        data = {
+        data: dict[str, Any] = {
             "name": self.name,
             "columns": columns_data,
         }
 
         if self.rules:
             data["rules"] = self.rules
+
+        serializable_cross = [r for r in self.cross_column_rules if r.check is None]
+        if serializable_cross:
+            cross_data = []
+            for r in serializable_cross:
+                rule_dict: dict[str, Any] = {
+                    "name": r.name,
+                    "left": r.left,
+                    "op": r.op,
+                    "right": r.right,
+                }
+                if r.error_message:
+                    rule_dict["error_message"] = r.error_message
+                cross_data.append(rule_dict)
+            data["cross_column_rules"] = cross_data
+
         if self.description:
             data["description"] = self.description
 

--- a/src/dqflow/engines/pandas.py
+++ b/src/dqflow/engines/pandas.py
@@ -2,12 +2,25 @@
 
 from __future__ import annotations
 
+import operator as _op
+from collections.abc import Callable
+from typing import Any
+
 import pandas as pd
 
-from dqflow.column import Column
+from dqflow.column import Column, CrossColumnRule
 from dqflow.contract import Contract
 from dqflow.engines.base import Engine
 from dqflow.result import CheckResult, ValidationResult
+
+_OPS: dict[str, Callable[[Any, Any], Any]] = {
+    ">=": _op.ge,
+    "<=": _op.le,
+    ">": _op.gt,
+    "<": _op.lt,
+    "==": _op.eq,
+    "!=": _op.ne,
+}
 
 
 class PandasEngine(Engine):
@@ -17,9 +30,8 @@ class PandasEngine(Engine):
         self,
         data: pd.DataFrame,
         contract: Contract,
-        **kwargs,
+        **kwargs: Any,
     ) -> ValidationResult:
-
         df = data  # normalize name for internal use
 
         result = ValidationResult(contract_name=contract.name)
@@ -52,6 +64,10 @@ class PandasEngine(Engine):
         for rule in contract.rules:
             result.checks.append(self._evaluate_rule(df, rule, cache))
 
+        # 4. CROSS-COLUMN RULES
+        for cc_rule in contract.cross_column_rules:
+            result.checks.append(self._evaluate_cross_column_rule(df, cc_rule))
+
         return result
 
     # COLUMN VALIDATION
@@ -62,7 +78,6 @@ class PandasEngine(Engine):
         col_name: str,
         col_def: Column,
     ) -> list[CheckResult]:
-
         checks: list[CheckResult] = []
 
         # NOT NULL
@@ -159,7 +174,6 @@ class PandasEngine(Engine):
         rule: str,
         cache: dict[str, dict[str, float | int]],
     ) -> CheckResult:
-
         try:
             context = {
                 "row_count": len(df),
@@ -180,4 +194,37 @@ class PandasEngine(Engine):
                 name=f"rule:{rule}",
                 passed=False,
                 message=f"Failed to evaluate rule: {e}",
+            )
+
+    def _evaluate_cross_column_rule(
+        self,
+        df: pd.DataFrame,
+        rule: CrossColumnRule,
+    ) -> CheckResult:
+        try:
+            if rule.check is not None:
+                mask: Any = rule.check(df)
+            else:
+                assert rule.left is not None and rule.op is not None
+                left_series = df[rule.left]
+                right_val: Any = (
+                    df[rule.right]
+                    if isinstance(rule.right, str) and rule.right in df.columns
+                    else rule.right
+                )
+                mask = _OPS[rule.op](left_series, right_val)
+
+            failing_rows = int((~mask).sum())
+            passed = failing_rows == 0
+            return CheckResult(
+                name=f"cross_column:{rule.name}",
+                passed=passed,
+                message=rule.error_message if not passed else "",
+                details={"failing_rows": failing_rows},
+            )
+        except Exception as e:
+            return CheckResult(
+                name=f"cross_column:{rule.name}",
+                passed=False,
+                message=f"Failed to evaluate cross-column rule '{rule.name}': {e}",
             )

--- a/src/dqflow/engines/polars.py
+++ b/src/dqflow/engines/polars.py
@@ -2,12 +2,25 @@
 
 from __future__ import annotations
 
+import operator as _op
+from collections.abc import Callable
+from typing import Any
+
 import polars as pl
 
-from dqflow.column import Column
+from dqflow.column import Column, CrossColumnRule
 from dqflow.contract import Contract
 from dqflow.engines.base import Engine
 from dqflow.result import CheckResult, ValidationResult
+
+_OPS: dict[str, Callable[[Any, Any], Any]] = {
+    ">=": _op.ge,
+    "<=": _op.le,
+    ">": _op.gt,
+    "<": _op.lt,
+    "==": _op.eq,
+    "!=": _op.ne,
+}
 
 
 class PolarsEngine(Engine):
@@ -17,9 +30,8 @@ class PolarsEngine(Engine):
         self,
         data: pl.DataFrame | pl.LazyFrame,
         contract: Contract,
-        **kwargs,
+        **kwargs: Any,
     ) -> ValidationResult:
-
         if isinstance(data, pl.LazyFrame):
             data = data.collect()
 
@@ -51,6 +63,10 @@ class PolarsEngine(Engine):
         for rule in contract.rules:
             result.checks.append(self._evaluate_rule(df, rule, cache))
 
+        # 4. CROSS-COLUMN RULES
+        for cc_rule in contract.cross_column_rules:
+            result.checks.append(self._evaluate_cross_column_rule(df, cc_rule))
+
         return result
 
     # COLUMN VALIDATION
@@ -61,7 +77,6 @@ class PolarsEngine(Engine):
         col_name: str,
         col_def: Column,
     ) -> list[CheckResult]:
-
         checks: list[CheckResult] = []
 
         # NOT NULL
@@ -158,7 +173,6 @@ class PolarsEngine(Engine):
         rule: str,
         cache: dict[str, dict[str, float | int]],
     ) -> CheckResult:
-
         try:
             context = {
                 "row_count": len(df),
@@ -179,4 +193,37 @@ class PolarsEngine(Engine):
                 name=f"rule:{rule}",
                 passed=False,
                 message=f"Failed to evaluate rule: {e}",
+            )
+
+    def _evaluate_cross_column_rule(
+        self,
+        df: pl.DataFrame,
+        rule: CrossColumnRule,
+    ) -> CheckResult:
+        try:
+            if rule.check is not None:
+                mask: Any = rule.check(df)
+            else:
+                assert rule.left is not None and rule.op is not None
+                left_series = df[rule.left]
+                right_val: Any = (
+                    df[rule.right]
+                    if isinstance(rule.right, str) and rule.right in df.columns
+                    else rule.right
+                )
+                mask = _OPS[rule.op](left_series, right_val)
+
+            failing_rows = int((~mask).sum())
+            passed = failing_rows == 0
+            return CheckResult(
+                name=f"cross_column:{rule.name}",
+                passed=passed,
+                message=rule.error_message if not passed else "",
+                details={"failing_rows": failing_rows},
+            )
+        except Exception as e:
+            return CheckResult(
+                name=f"cross_column:{rule.name}",
+                passed=False,
+                message=f"Failed to evaluate cross-column rule '{rule.name}': {e}",
             )

--- a/src/dqflow/engines/polars.py
+++ b/src/dqflow/engines/polars.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import operator as _op
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import polars as pl
 
@@ -93,7 +93,7 @@ class PolarsEngine(Engine):
 
         # MIN
         if col_def.min is not None:
-            min_val = series.min()
+            min_val = cast("float | None", series.min())
             passed = min_val is None or min_val >= col_def.min
 
             checks.append(
@@ -103,13 +103,13 @@ class PolarsEngine(Engine):
                     message=(
                         f"Minimum value {min_val} is below {col_def.min}" if not passed else ""
                     ),
-                    details={"actual_min": float(min_val) if min_val is not None else None},
+                    details={"actual_min": min_val},
                 )
             )
 
         # MAX
         if col_def.max is not None:
-            max_val = series.max()
+            max_val = cast("float | None", series.max())
             passed = max_val is None or max_val <= col_def.max
 
             checks.append(
@@ -119,7 +119,7 @@ class PolarsEngine(Engine):
                     message=(
                         f"Maximum value {max_val} exceeds {col_def.max}" if not passed else ""
                     ),
-                    details={"actual_max": float(max_val) if max_val is not None else None},
+                    details={"actual_max": max_val},
                 )
             )
 

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -62,7 +62,6 @@ class TestParallelValidation:
         sample_contract: Contract,
         sample_df: pd.DataFrame,
     ) -> None:
-
         from dqflow.engines.pandas import PandasEngine
 
         engine = PandasEngine()

--- a/tests/test_cross_column_rules.py
+++ b/tests/test_cross_column_rules.py
@@ -1,0 +1,300 @@
+"""Tests for cross-column validation rules."""
+
+from __future__ import annotations
+
+import pandas as pd
+import polars as pl
+import pytest
+
+from dqflow import Column, Contract, CrossColumnRule
+from dqflow.engines.pandas import PandasEngine
+from dqflow.engines.polars import PolarsEngine
+
+
+class TestCrossColumnRuleValidation:
+    """CrossColumnRule raises on invalid construction."""
+
+    def test_must_provide_check_or_structured(self) -> None:
+        with pytest.raises(ValueError, match="provide either"):
+            CrossColumnRule(name="bad")
+
+    def test_cannot_provide_both(self) -> None:
+        with pytest.raises(ValueError, match="not both"):
+            CrossColumnRule(
+                name="bad",
+                check=lambda df: df["a"] > df["b"],
+                left="a",
+                op=">",
+                right="b",
+            )
+
+    def test_unknown_op_raises(self) -> None:
+        with pytest.raises(ValueError, match="[Uu]nsupported op"):
+            CrossColumnRule(name="bad", left="a", op="??", right="b")
+
+    def test_right_zero_is_valid(self) -> None:
+        rule = CrossColumnRule(name="positive", left="amount", op=">", right=0)
+        assert rule.right == 0
+
+
+class TestStructuredRulePandas:
+    """Structured cross-column rules evaluated by PandasEngine."""
+
+    def _contract(self, *rules: CrossColumnRule) -> Contract:
+        return Contract(
+            name="test",
+            columns={"start": Column(int), "end": Column(int)},
+            cross_column_rules=list(rules),
+        )
+
+    def test_passes_when_all_rows_satisfy(self) -> None:
+        df = pd.DataFrame({"start": [1, 2, 3], "end": [4, 5, 6]})
+        result = self._contract(
+            CrossColumnRule(name="end_after_start", left="end", op=">=", right="start")
+        ).validate(df)
+
+        check = next(c for c in result.checks if c.name == "cross_column:end_after_start")
+        assert check.passed
+        assert check.details["failing_rows"] == 0
+
+    def test_fails_and_counts_failing_rows(self) -> None:
+        df = pd.DataFrame({"start": [1, 5, 3], "end": [4, 2, 6]})
+        result = self._contract(
+            CrossColumnRule(
+                name="end_after_start",
+                left="end",
+                op=">=",
+                right="start",
+                error_message="end must be >= start",
+            )
+        ).validate(df)
+
+        check = next(c for c in result.checks if c.name == "cross_column:end_after_start")
+        assert not check.passed
+        assert check.details["failing_rows"] == 1
+        assert check.message == "end must be >= start"
+
+    def test_right_as_literal_value(self) -> None:
+        df = pd.DataFrame({"start": [1, 2, 3], "end": [10, -1, 5]})
+        contract = Contract(
+            name="test",
+            columns={"end": Column(int)},
+            cross_column_rules=[CrossColumnRule(name="positive_end", left="end", op=">", right=0)],
+        )
+        result = contract.validate(df)
+        check = next(c for c in result.checks if c.name == "cross_column:positive_end")
+        assert not check.passed
+        assert check.details["failing_rows"] == 1
+
+    def test_all_operators(self) -> None:
+        df = pd.DataFrame({"a": [5], "b": [5]})
+        contract = Contract(name="test", columns={"a": Column(int), "b": Column(int)})
+
+        for op, expected in [
+            (">=", True),
+            ("<=", True),
+            ("==", True),
+            ("!=", False),
+            (">", False),
+            ("<", False),
+        ]:
+            contract.cross_column_rules = [
+                CrossColumnRule(name="check", left="a", op=op, right="b")
+            ]
+            result = contract.validate(df)
+            check = next(c for c in result.checks if c.name == "cross_column:check")
+            assert check.passed == expected, f"op={op!r} expected passed={expected}"
+
+    def test_missing_column_returns_failed_check(self) -> None:
+        df = pd.DataFrame({"start": [1, 2, 3]})
+        contract = Contract(
+            name="test",
+            columns={"start": Column(int)},
+            cross_column_rules=[
+                CrossColumnRule(name="bad", left="nonexistent", op=">", right="start")
+            ],
+        )
+        result = contract.validate(df)
+        check = next(c for c in result.checks if c.name == "cross_column:bad")
+        assert not check.passed
+        assert "nonexistent" in check.message
+
+
+class TestCallableRulePandas:
+    """Callable cross-column rules evaluated by PandasEngine."""
+
+    def test_callable_passes(self) -> None:
+        df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        contract = Contract(
+            name="test",
+            columns={"a": Column(int), "b": Column(int)},
+            cross_column_rules=[CrossColumnRule(name="b_gt_a", check=lambda d: d["b"] > d["a"])],
+        )
+        result = contract.validate(df)
+        check = next(c for c in result.checks if c.name == "cross_column:b_gt_a")
+        assert check.passed
+        assert check.details["failing_rows"] == 0
+
+    def test_callable_fails_with_correct_count(self) -> None:
+        df = pd.DataFrame({"a": [1, 10, 3], "b": [4, 5, 6]})
+        contract = Contract(
+            name="test",
+            columns={"a": Column(int), "b": Column(int)},
+            cross_column_rules=[
+                CrossColumnRule(
+                    name="b_gt_a",
+                    check=lambda d: d["b"] > d["a"],
+                    error_message="b must be greater than a",
+                )
+            ],
+        )
+        result = contract.validate(df)
+        check = next(c for c in result.checks if c.name == "cross_column:b_gt_a")
+        assert not check.passed
+        assert check.details["failing_rows"] == 1
+        assert check.message == "b must be greater than a"
+
+
+class TestCrossColumnEngineConsistency:
+    """PandasEngine and PolarsEngine produce identical CheckResult structures."""
+
+    def test_structured_rule_consistency(self) -> None:
+        rule = CrossColumnRule(
+            name="end_after_start",
+            left="end",
+            op=">=",
+            right="start",
+            error_message="end must be >= start",
+        )
+        contract = Contract(
+            name="test",
+            columns={"start": Column(int), "end": Column(int)},
+            cross_column_rules=[rule],
+        )
+
+        pdf = pd.DataFrame({"start": [1, 5, 3], "end": [4, 2, 6]})
+        pldf = pl.DataFrame({"start": [1, 5, 3], "end": [4, 2, 6]})
+
+        pandas_result = PandasEngine().validate(pdf, contract)
+        polars_result = PolarsEngine().validate(pldf, contract)
+
+        p_check = next(c for c in pandas_result.checks if c.name == "cross_column:end_after_start")
+        pl_check = next(c for c in polars_result.checks if c.name == "cross_column:end_after_start")
+
+        assert p_check.passed == pl_check.passed
+        assert p_check.message == pl_check.message
+        assert p_check.details["failing_rows"] == pl_check.details["failing_rows"]
+
+    def test_literal_right_consistency(self) -> None:
+        contract = Contract(
+            name="test",
+            columns={"amount": Column(float)},
+            cross_column_rules=[CrossColumnRule(name="positive", left="amount", op=">", right=0)],
+        )
+        pdf = pd.DataFrame({"amount": [10.0, -5.0, 20.0]})
+        pldf = pl.DataFrame({"amount": [10.0, -5.0, 20.0]})
+
+        p_check = next(
+            c
+            for c in PandasEngine().validate(pdf, contract).checks
+            if c.name == "cross_column:positive"
+        )
+        pl_check = next(
+            c
+            for c in PolarsEngine().validate(pldf, contract).checks
+            if c.name == "cross_column:positive"
+        )
+
+        assert p_check.passed == pl_check.passed
+        assert p_check.details["failing_rows"] == pl_check.details["failing_rows"]
+
+
+class TestCrossColumnRuleYaml:
+    """YAML serialization and deserialization of cross_column_rules."""
+
+    def test_from_yaml(self, tmp_path: pytest.TempPathFactory) -> None:
+        yaml_content = """\
+name: orders
+columns:
+  start_date:
+    dtype: integer
+  end_date:
+    dtype: integer
+cross_column_rules:
+  - name: end_after_start
+    left: end_date
+    op: ">="
+    right: start_date
+    error_message: "end_date must not precede start_date"
+"""
+        f = tmp_path / "contract.yaml"  # type: ignore[operator]
+        f.write_text(yaml_content)
+
+        contract = Contract.from_yaml(f)
+        assert len(contract.cross_column_rules) == 1
+        rule = contract.cross_column_rules[0]
+        assert rule.name == "end_after_start"
+        assert rule.left == "end_date"
+        assert rule.op == ">="
+        assert rule.right == "start_date"
+        assert rule.error_message == "end_date must not precede start_date"
+
+    def test_from_yaml_literal_right(self, tmp_path: pytest.TempPathFactory) -> None:
+        yaml_content = """\
+name: orders
+columns:
+  amount:
+    dtype: float
+cross_column_rules:
+  - name: positive_amount
+    left: amount
+    op: ">"
+    right: 0
+"""
+        f = tmp_path / "contract.yaml"  # type: ignore[operator]
+        f.write_text(yaml_content)
+
+        contract = Contract.from_yaml(f)
+        assert contract.cross_column_rules[0].right == 0
+
+    def test_to_yaml_round_trip(self, tmp_path: pytest.TempPathFactory) -> None:
+        contract = Contract(
+            name="orders",
+            columns={"start": Column(int), "end": Column(int)},
+            cross_column_rules=[
+                CrossColumnRule(
+                    name="end_after_start",
+                    left="end",
+                    op=">=",
+                    right="start",
+                    error_message="end must be >= start",
+                )
+            ],
+        )
+        path = tmp_path / "out.yaml"  # type: ignore[operator]
+        contract.to_yaml(path)
+        reloaded = Contract.from_yaml(path)
+
+        assert len(reloaded.cross_column_rules) == 1
+        r = reloaded.cross_column_rules[0]
+        assert r.name == "end_after_start"
+        assert r.left == "end"
+        assert r.op == ">="
+        assert r.right == "start"
+        assert r.error_message == "end must be >= start"
+
+    def test_callable_rules_not_serialized(self, tmp_path: pytest.TempPathFactory) -> None:
+        contract = Contract(
+            name="test",
+            columns={"a": Column(int), "b": Column(int)},
+            cross_column_rules=[
+                CrossColumnRule(name="callable_rule", check=lambda d: d["a"] > d["b"]),
+                CrossColumnRule(name="structured_rule", left="a", op=">", right="b"),
+            ],
+        )
+        path = tmp_path / "out.yaml"  # type: ignore[operator]
+        contract.to_yaml(path)
+        reloaded = Contract.from_yaml(path)
+
+        assert len(reloaded.cross_column_rules) == 1
+        assert reloaded.cross_column_rules[0].name == "structured_rule"


### PR DESCRIPTION
## Summary

- Introduces `CrossColumnRule` dataclass in `column.py` with two usage modes: structured (`left`/`op`/`right`) and callable (`check=lambda df: ...`)
- Structured rules are resolved via an operator lookup table (`operator.ge`, `operator.le`, etc.) — zero use of `eval`, `DataFrame.eval()`, or `pl.sql_expr()`
- Both `PandasEngine` and `PolarsEngine` evaluate `cross_column_rules` as step 4 in `validate()`, reporting `failing_rows` in `CheckResult.details`
- `Contract.from_yaml` / `to_yaml` support structured rules; callable rules are silently skipped during YAML serialization (they can't be serialized)
- `CrossColumnRule` exported from top-level `dqflow` package

Closes #28

## Test plan

- [ ] `pytest tests/test_cross_column_rules.py` — 17 new tests covering construction validation, structured rules, callable rules, engine consistency, and YAML round-trip
- [ ] `pytest` — full suite (48 tests), no regressions
- [ ] `ruff check .` — no lint errors
- [ ] `mypy src/dqflow` — no type errors