### PR TITLE
Updated Visuals Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
   <picture>
     <source
       media="(prefers-color-scheme: dark)"
-      srcset="https://raw.githubusercontent.com/dqflow/dqflow/docs/assets/dqflow-logo-dark.png"
+      srcset="./docs/assets/dqflow-logo-dark.png"
     />
     <source
       media="(prefers-color-scheme: light)"
-      srcset="https://raw.githubusercontent.com/dqflow/dqflow/docs/assets/dqflow-logo-light.png"
+      srcset="./docs/assets/dqflow-logo-light.png"
     />
     <img
-      src="https://raw.githubusercontent.com/dqflow/dqflow/docs/assets/dqflow-logo-dark.png"
+      src="./docs/assets/dqflow-logo-dark.png"
       width="400"
       alt="Dqflow Logo"
     />

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,14 +6,14 @@
   <picture>
     <source
       media="(prefers-color-scheme: dark)"
-      srcset="https://raw.githubusercontent.com/dqflow/dqflow/docs/assets/dqflow-logo-dark.png"
+      srcset="./docs/assets/dqflow-logo-dark.png"
     />
     <source
       media="(prefers-color-scheme: light)"
-      srcset="https://raw.githubusercontent.com/dqflow/dqflow/docs/assets/dqflow-logo-light.png"
+      srcset="./docs/assets/dqflow-logo-light.png"
     />
     <img
-      src="https://raw.githubusercontent.com/dqflow/dqflow/docs/assets/dqflow-logo-dark.png"
+      src="./docs/assets/dqflow-logo-dark.png"
       width="400"
       alt="Dqflow Logo"
     />


### PR DESCRIPTION
The links to the logos used in the readme and index markdown files are now set to relative to prevent preview errors in the files.